### PR TITLE
REWORK: Added separate `config`s

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,22 +1,24 @@
 module.exports = {
-  extends: "eslint-config-standard",
-  rules: {
-    "no-multiple-empty-lines": [0, false],
-    "brace-style": [2, "stroustrup"],
-    "generator-star-spacing": [2, {
-      "before": false,
-      "after": true,
-      "anonymous": "neither",
-      "method": {
-        "before": true,
-        "after": true
+  configs: {
+    parity: {
+      rules: {
+        "no-multiple-empty-lines": [0, false],
+        "brace-style": [2, "stroustrup"],
+        "generator-star-spacing": [2, {
+          "before": false,
+          "after": true,
+          "anonymous": "neither",
+          "method": {
+            "before": true,
+            "after": true
+          }
+        }],
+        "indent": [2, 2],
+        "quotes": [2, "double"],
+        "semi": [2, "always"],
+        "semi-style": [2, "last"],
+        "space-before-function-paren": [0, false]	
       }
-    }],
-    "indent": [2, 2],
-    "quotes": [2, "double"],
-    "semi": [2, "always"],
-    "semi-style": [2, "last"],
-    "space-before-function-paren": [0, false]
+    }
   }
 };
-

--- a/package.json
+++ b/package.json
@@ -1,10 +1,6 @@
 {
   "name": "eslint-plugin-bestow",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "main": "main.js",
-  "private": true,
-  "license": "proprietary",
-  "dependencies": {
-    "eslint-config-standard": "^14.1.0"
-  }
+  "private": true
 }


### PR DESCRIPTION
This one works.

When referred to in a project's `.eslintrc.json`, it should look like:
```json
"extends": [
  "standard",
  "plugin:bestow/parity"
],
"plugins": [
	"jest",
	"bestow"
]
```
(e.g., in `steam-enroller`'s `.eslintrc.json`, other keys omitted for
brevity.)

For further refixes, this is our guide (FWIW):
https://eslint.org/docs/developer-guide/working-with-plugins