### PR TITLE
ENST-1648 Package private license

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,8 @@
 {
   "name": "eslint-plugin-bestow",
-  "version": "0.0.2",
+  "version": "0.0.4",
   "main": "main.js",
-  "private": true
+  "private": true,
+  "description": "Eslint plugin with configs for all Bestow JS projects.",
+  "license": "UNLICENSED"
 }


### PR DESCRIPTION
* Got tired of warning, "UNLICENSED" is, strangely enough, the official solution:
  https://docs.npmjs.com/files/package.json#license
  Otherwise, it must be a SPDX-recognized license. The only other option is to
  reference a file with more text in it (which we can do anytime). To reiterate:
  the package _is_ private.