### PR TITLE
EXTRAS - Started new config twentyTwenty

### DIFF
--- a/main.js
+++ b/main.js
@@ -17,7 +17,17 @@ module.exports = {
         "quotes": [2, "double"],
         "semi": [2, "always"],
         "semi-style": [2, "last"],
-        "space-before-function-paren": [0, false]	
+        "space-before-function-paren": [0, false]
+      }
+    },
+    twentyTwenty: {
+      rules: {
+        "one-var": [0, false],
+        "comma-dangle": [0, false],
+        "generator-star-spacing": [1, {
+          "before": true,
+          "after": true
+        }]
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eslint-plugin-bestow",
   "url": "git+ssh://git@github.com/Bestowinc/eslint-plugin-bestow.git",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "main": "main.js",
   "private": true,
   "description": "Eslint plugin with configs for all Bestow JS projects.",


### PR DESCRIPTION
Note that this is currently opt-in; `eslint` behavior doesn't change unless you do the following to `steam-enroller` (or whatever repo is using the plugin) `package.json`.

To opt in, add the following to `.eslintrc.json`:
```json
  "extends": [
    "react-app",
    "standard",
    "plugin:bestow/parity",
    "plugin:bestow/twentyTwenty"
  ],
```

v0.0.6 Some modernization
* Allow optional "one-var" (e.g., `const foo, bar;`
* Allow optional "comma-dangle" (`{foo, bar,}`), for easy copy/paste.
* Allow spaces before and after star on generator functions.
  (warning only).